### PR TITLE
Refactor AudioResource and Update CacheManager

### DIFF
--- a/Ye-Dufu/Packages/HConstants/Sources/HConstants/Logger.swift
+++ b/Ye-Dufu/Packages/HConstants/Sources/HConstants/Logger.swift
@@ -2,21 +2,30 @@ import Foundation
 import OSLog
 
 public struct HLog {
-    private static let logger = Logger(subsystem: "com.yedufu.hdata", category: "General")
-
-    public static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(message, type: .debug, file: file, function: function, line: line)
+    public enum Category: String {
+        case general = "General"
+        case ui = "UI"
+        case network = "Network"
+        case data = "Data"
+        case media = "Media"
     }
 
-    public static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(message, type: .info, file: file, function: function, line: line)
+    private static let subsystem = "com.yedufu"
+
+    public static func debug(_ message: String, category: Category = .general, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, type: .debug, category: category, file: file, function: function, line: line)
     }
 
-    public static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(message, type: .error, file: file, function: function, line: line)
+    public static func info(_ message: String, category: Category = .general, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, type: .info, category: category, file: file, function: function, line: line)
     }
 
-    private static func log(_ message: String, type: OSLogType, file: String, function: String, line: Int) {
+    public static func error(_ message: String, category: Category = .general, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, type: .error, category: category, file: file, function: function, line: line)
+    }
+
+    private static func log(_ message: String, type: OSLogType, category: Category, file: String, function: String, line: Int) {
+        let logger = Logger(subsystem: subsystem, category: category.rawValue)
         let fileName = (file as NSString).lastPathComponent
         let logMessage = "[\(fileName):\(line)] \(function) - \(message)"
         logger.log(level: type, "\(logMessage)")

--- a/Ye-Dufu/Packages/HData/Sources/HData/AudioResource.swift
+++ b/Ye-Dufu/Packages/HData/Sources/HData/AudioResource.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AudioResource: Sendable {
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+}

--- a/Ye-Dufu/Packages/HData/Sources/HData/CacheManager.swift
+++ b/Ye-Dufu/Packages/HData/Sources/HData/CacheManager.swift
@@ -28,6 +28,10 @@ public class CacheManager {
         }
         return nil
     }
+
+    public func getLocalURL(for resource: AudioResource) -> URL? {
+        return getLocalURL(for: resource.url)
+    }
     
     public func cache(remoteURL: URL) {
         let fileName = remoteURL.lastPathComponent
@@ -59,5 +63,9 @@ public class CacheManager {
             }
         }
         task.resume()
+    }
+
+    public func cache(resource: AudioResource) {
+        cache(remoteURL: resource.url)
     }
 }


### PR DESCRIPTION
Refactors `AudioResource` to be part of `HData` and updates `CacheManager` to support caching by `AudioResource`.

## Changes
- Moved `AudioResource` from `HMedia` to `HData`.
- Added `cache(resource:)` and `getLocalURL(for resource:)` to `CacheManager`.
- Updated `HMedia` to depend on `HData`.

Closes #2