### PR TITLE
feat: Add Download Manager and observable CacheManager

### DIFF
--- a/.github/agents/implement.agent.md
+++ b/.github/agents/implement.agent.md
@@ -1,0 +1,12 @@
+---
+description: 'To implement ios dev coding tasks.'
+tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'apple-docs/*', 'agent', 'todo']
+---
+You are an expert ios developer. You will be given coding tasks related to ios development. Use your tools to complete the tasks efficiently and accurately.
+Focus on writing clean, maintainable code and follow best practices for ios development. If you encounter any issues or need additional information, utilize the available tools to research and resolve them.
+Prioritize clarity, accuracy, and efficiency in your responses.
+When implementing code, ensure that it adheres to the latest ios development standards and guidelines.
+If you need to reference official Apple documentation, use the apple-docs tool to find relevant information.
+When you complete a task, provide a brief summary of the changes made and any important notes for future reference.
+Make sure the code is well-documented with comments where necessary.
+make sure the project can compile following the [make_build_success](../prompts/make_build_success.prompt.md) instructions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,12 @@ The minimum iOS deployment target is iOS 26. I want to use the new Observable pa
 
 When writing code, please follow these rules:
 - Use logger defined in HConstants package for logging.
+- Use HData package for data storage and retrieval.
+- Use HConstants package for constants definition.
+- Use HMedia package for media playback.
+- Use SF Symbols for icons wherever possible.
+- Use observable pattern for state management in UIKit.
+
 
 
 Use modern Swift syntax and best practices.

--- a/.github/prompts/plan-addDownloadManagerPage.prompt.md
+++ b/.github/prompts/plan-addDownloadManagerPage.prompt.md
@@ -1,0 +1,25 @@
+## Plan: Add Download Manager Page
+
+I will create a new "Download Manager" page to view download status and trigger downloads for audio files, and update the `CacheManager` to support observability.
+
+### Steps
+1.  **Update `CacheManager` in `HData`**:
+    -   Mark `CacheManager` as `@Observable`.
+    -   Add `downloadingURLs` property to track active downloads.
+    -   Add `isDownloaded(resource:)` and `isDownloading(resource:)` helper methods.
+    -   Update `cache(remoteURL:)` to manage the `downloadingURLs` state.
+
+2.  **Create `DownloadManagerViewController`**:
+    -   Create a new `UIViewController` subclass with a `UITableView`.
+    -   Display the list of chapters (`Chapter.all`).
+    -   Implement cells to show the title and a dynamic action button (Download / Downloading... / Downloaded).
+    -   Use `withObservationTracking` to observe `CacheManager.shared` and update UI automatically.
+
+3.  **Update `ViewController`**:
+    -   Add a "Downloads" button (icon: `arrow.down.circle`) to the top-right of the screen.
+    -   Implement the action to present `DownloadManagerViewController` modally.
+
+### Further Considerations
+1.  **Navigation**: I will present the new page modally since the current `ViewController` structure doesn't explicitly use a Navigation Controller.
+2.  **Progress**: The current `URLSession` implementation doesn't easily support progress updates without a delegate. I will stick to a simple "Downloading..." state for now as requested.
+3.  **Deletion**: The user didn't ask for deletion, so I will only implement "Download" and "View Status".

--- a/Ye-Dufu/Packages/HConstants/Sources/HConstants/HConstants.swift
+++ b/Ye-Dufu/Packages/HConstants/Sources/HConstants/HConstants.swift
@@ -1,2 +1,6 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
+
+public enum HConstants {
+    public static let appTitle = "叶嘉莹说杜甫诗"
+}

--- a/Ye-Dufu/Packages/HData/Sources/HData/CacheManager.swift
+++ b/Ye-Dufu/Packages/HData/Sources/HData/CacheManager.swift
@@ -1,15 +1,32 @@
 import Foundation
 import HConstants
+import Observation
 
-public class CacheManager {
+public struct DownloadState: Sendable {
+    public let progress: Double
+    public let totalBytesWritten: Int64
+    public let totalBytesExpectedToWrite: Int64
+}
+
+@Observable
+final public class  CacheManager: NSObject, URLSessionDownloadDelegate {
     @MainActor public static let shared = CacheManager()
+    
+    public var downloadingURLs: Set<URL> = []
+    public var downloadStates: [URL: DownloadState] = [:]
+    public var cacheUpdateToken: UUID = UUID()
     
     private let fileManager = FileManager.default
     private let cacheDirectory: URL
+    private var session: URLSession!
     
-    private init() {
+    private override init() {
         let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
         cacheDirectory = documentsDirectory.appendingPathComponent("Media")
+        super.init()
+        
+        let config = URLSessionConfiguration.default
+        self.session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         
         createCacheDirectory()
     }
@@ -41,6 +58,36 @@ public class CacheManager {
         return getLocalURL(for: resource.url)
     }
     
+    public func isDownloaded(resource: AudioResource) -> Bool {
+        return getLocalURL(for: resource) != nil
+    }
+    
+    public func isDownloading(resource: AudioResource) -> Bool {
+        return downloadingURLs.contains(resource.url)
+    }
+    
+    public func getProgress(for resource: AudioResource) -> Double? {
+        return downloadStates[resource.url]?.progress
+    }
+    
+    public func getDownloadState(for resource: AudioResource) -> DownloadState? {
+        return downloadStates[resource.url]
+    }
+    
+    public func getFileSize(for resource: AudioResource) -> String? {
+        guard let localURL = getLocalURL(for: resource) else { return nil }
+        do {
+            let attributes = try fileManager.attributesOfItem(atPath: localURL.path)
+            if let size = attributes[.size] as? Int64 {
+                return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+            }
+        } catch {
+            HLog.error("Failed to get file size: \(error)", category: .data)
+            return nil
+        }
+        return nil
+    }
+    
     public func cache(remoteURL: URL) {
         let fileName = remoteURL.lastPathComponent
         let localURL = cacheDirectory.appendingPathComponent(fileName)
@@ -49,32 +96,87 @@ public class CacheManager {
             return
         }
         
-        HLog.info("Starting download for \(fileName)", category: .network)
-        let task = URLSession.shared.downloadTask(with: remoteURL) { [weak self] tempURL, response, error in
-            guard let self = self, let tempURL = tempURL, error == nil else {
-                HLog.error("Download failed: \(String(describing: error))", category: .network)
-                return
-            }
-            
-            do {
-                // Ensure the directory exists before moving (just in case)
-                self.createCacheDirectory()
-                
-                // If file exists at destination (race condition), remove it first or handle error
-                if self.fileManager.fileExists(atPath: localURL.path) {
-                    try self.fileManager.removeItem(at: localURL)
-                }
-                
-                try self.fileManager.moveItem(at: tempURL, to: localURL)
-                HLog.info("Cached file at: \(localURL.path)", category: .data)
-            } catch {
-                HLog.error("Failed to move file: \(error)", category: .data)
-            }
+        if downloadingURLs.contains(remoteURL) {
+            return
         }
+        
+        downloadingURLs.insert(remoteURL)
+        downloadStates[remoteURL] = DownloadState(progress: 0.0, totalBytesWritten: 0, totalBytesExpectedToWrite: 0)
+        
+        HLog.info("Starting download for \(fileName)", category: .network)
+        let task = session.downloadTask(with: remoteURL)
         task.resume()
     }
 
     public func cache(resource: AudioResource) {
         cache(remoteURL: resource.url)
+    }
+    
+    public func removeCache(for resource: AudioResource) {
+        let fileName = resource.url.lastPathComponent
+        let localURL = cacheDirectory.appendingPathComponent(fileName)
+        
+        if fileManager.fileExists(atPath: localURL.path) {
+            do {
+                try fileManager.removeItem(at: localURL)
+                HLog.info("Removed cached file at: \(localURL.path)", category: .data)
+                cacheUpdateToken = UUID()
+            } catch {
+                HLog.error("Failed to remove file: \(error)", category: .data)
+            }
+        }
+    }
+    
+    // MARK: - URLSessionDownloadDelegate
+    
+    public nonisolated func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        guard let url = downloadTask.originalRequest?.url else { return }
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        let state = DownloadState(progress: progress, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
+        
+        Task { @MainActor in
+            self.downloadStates[url] = state
+        }
+    }
+    
+    public nonisolated func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        guard let url = downloadTask.originalRequest?.url else { return }
+        let fileName = url.lastPathComponent
+        let localURL = cacheDirectory.appendingPathComponent(fileName)
+        
+        do {
+            // Ensure the directory exists before moving (just in case)
+            if !fileManager.fileExists(atPath: cacheDirectory.path) {
+                try fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)
+            }
+            
+            // If file exists at destination (race condition), remove it first or handle error
+            if fileManager.fileExists(atPath: localURL.path) {
+                try fileManager.removeItem(at: localURL)
+            }
+            
+            try fileManager.moveItem(at: location, to: localURL)
+            HLog.info("Cached file at: \(localURL.path)", category: .data)
+        } catch {
+            HLog.error("Failed to move file: \(error)", category: .data)
+        }
+        
+        Task { @MainActor in
+            self.downloadingURLs.remove(url)
+            self.downloadStates.removeValue(forKey: url)
+            self.cacheUpdateToken = UUID()
+        }
+    }
+    
+    public nonisolated func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let url = task.originalRequest?.url else { return }
+        
+        if let error = error {
+            HLog.error("Download failed: \(error)", category: .network)
+            Task { @MainActor in
+                self.downloadingURLs.remove(url)
+                self.downloadStates.removeValue(forKey: url)
+            }
+        }
     }
 }

--- a/Ye-Dufu/Ye-Dufu/DownloadManagerViewController.swift
+++ b/Ye-Dufu/Ye-Dufu/DownloadManagerViewController.swift
@@ -1,0 +1,202 @@
+import UIKit
+import HMedia
+import HData
+import Observation
+import HConstants
+
+class DownloadManagerViewController: UIViewController {
+    private let tableView = UITableView()
+    private let cacheManager = CacheManager.shared
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupObservation()
+    }
+    
+    private func setupUI() {
+        title = "下载管理"
+        view.backgroundColor = .systemBackground
+        
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .always
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissSelf))
+        
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(DownloadCell.self, forCellReuseIdentifier: "DownloadCell")
+    }
+    
+    @objc private func dismissSelf() {
+        dismiss(animated: true)
+    }
+    
+    private func setupObservation() {
+        let updater = Updater(controller: self)
+        withObservationTracking {
+            _ = cacheManager.downloadingURLs
+            _ = cacheManager.downloadStates
+            _ = cacheManager.cacheUpdateToken
+            Task { @MainActor in
+                self.tableView.reloadData()
+            }
+        } onChange: {
+            Task { @MainActor in
+                updater.update()
+            }
+        }
+    }
+    
+    private struct Updater: Sendable {
+        weak var controller: DownloadManagerViewController?
+        @MainActor
+        func update() {
+            controller?.setupObservation()
+        }
+    }
+}
+
+extension DownloadManagerViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Chapter.all.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "DownloadCell", for: indexPath) as! DownloadCell
+        let chapter = Chapter.all[indexPath.row]
+        cell.configure(with: chapter)
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+class DownloadCell: UITableViewCell {
+    private let stackView = UIStackView()
+    private let titleLabel = UILabel()
+    private let detailLabel = UILabel()
+    private let progressView = UIProgressView(progressViewStyle: .default)
+    private let actionButton = UIButton(type: .system)
+    private let deleteButton = UIButton(type: .system)
+    private var chapter: Chapter?
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        contentView.addSubview(stackView)
+        contentView.addSubview(actionButton)
+        contentView.addSubview(deleteButton)
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        deleteButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        stackView.alignment = .fill
+        
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(detailLabel)
+        stackView.addArrangedSubview(progressView)
+        
+        detailLabel.font = .monospacedDigitSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular)
+        detailLabel.textColor = .secondaryLabel
+        
+        deleteButton.setImage(UIImage(systemName: "trash"), for: .normal)
+        deleteButton.tintColor = .systemRed
+        
+        NSLayoutConstraint.activate([
+            deleteButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            deleteButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            deleteButton.widthAnchor.constraint(equalToConstant: 44),
+            deleteButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            actionButton.trailingAnchor.constraint(equalTo: deleteButton.leadingAnchor, constant: -8),
+            actionButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: actionButton.leadingAnchor, constant: -16)
+        ])
+        
+        actionButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+    }
+    
+    func configure(with chapter: Chapter) {
+        self.chapter = chapter
+        titleLabel.text = chapter.title
+        updateButtonState()
+    }
+    
+    private func updateButtonState() {
+        guard let chapter = chapter else { return }
+        let cacheManager = CacheManager.shared
+        
+        if cacheManager.isDownloaded(resource: chapter.audioResource) {
+            actionButton.setTitle("Downloaded", for: .normal)
+            actionButton.isEnabled = false
+            deleteButton.isHidden = false
+            progressView.isHidden = true
+            if let size = cacheManager.getFileSize(for: chapter.audioResource) {
+                detailLabel.text = "Size: \(size)"
+            } else {
+                detailLabel.text = "Downloaded"
+            }
+        } else if cacheManager.isDownloading(resource: chapter.audioResource) {
+            actionButton.setTitle("Downloading...", for: .normal)
+            actionButton.isEnabled = false
+            deleteButton.isHidden = true
+            progressView.isHidden = false
+            
+            if let state = cacheManager.getDownloadState(for: chapter.audioResource) {
+                progressView.progress = Float(state.progress)
+                let written = ByteCountFormatter.string(fromByteCount: state.totalBytesWritten, countStyle: .file)
+                let total = ByteCountFormatter.string(fromByteCount: state.totalBytesExpectedToWrite, countStyle: .file)
+                detailLabel.text = "\(written) / \(total)"
+            } else {
+                progressView.progress = 0
+                detailLabel.text = "Downloading..."
+            }
+        } else {
+            actionButton.setTitle("Download", for: .normal)
+            actionButton.isEnabled = true
+            deleteButton.isHidden = true
+            progressView.isHidden = true
+            detailLabel.text = "Not Downloaded"
+        }
+    }
+    
+    @objc private func buttonTapped() {
+        guard let chapter = chapter else { return }
+        CacheManager.shared.cache(resource: chapter.audioResource)
+        // UI update will happen via observation
+        updateButtonState()
+    }
+    
+    @objc private func deleteButtonTapped() {
+        guard let chapter = chapter else { return }
+        CacheManager.shared.removeCache(for: chapter.audioResource)
+        // UI update will happen via observation
+        updateButtonState()
+    }
+}

--- a/Ye-Dufu/Ye-Dufu/SceneDelegate.swift
+++ b/Ye-Dufu/Ye-Dufu/SceneDelegate.swift
@@ -18,7 +18,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         HLog.info("Scene will connect", category: .ui)
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        let viewController = ViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        window.rootViewController = navigationController
+        self.window = window
+        window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Ye-Dufu/Ye-Dufu/ViewController.swift
+++ b/Ye-Dufu/Ye-Dufu/ViewController.swift
@@ -32,6 +32,9 @@ final class ViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .systemBackground
         
+        title = HConstants.appTitle
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.down.circle"), style: .plain, target: self, action: #selector(showDownloads))
+        
         // Add subviews
         view.addSubview(tableView)
         view.addSubview(miniPlayerView)
@@ -173,6 +176,13 @@ final class ViewController: UIViewController {
     @objc private func togglePlayPause() {
         HLog.info("Toggle play/pause tapped", category: .ui)
         player.togglePlayPause()
+    }
+    
+    @objc private func showDownloads() {
+        HLog.info("Show downloads tapped", category: .ui)
+        let downloadManagerVC = DownloadManagerViewController()
+        let nav = UINavigationController(rootViewController: downloadManagerVC)
+        present(nav, animated: true)
     }
     
     @objc private func showPlayerControl() {


### PR DESCRIPTION
This PR introduces a Download Manager feature and updates the `CacheManager` to support observability and progress tracking.

**Key Changes:**

*   **`CacheManager` (HData):**
    *   Refactored to use the `@Observable` macro for state management.
    *   Added support for tracking download progress (`downloadStates`) and active downloads (`downloadingURLs`).
    *   Implemented `URLSessionDownloadDelegate` to handle download events and progress updates.
    *   Added helper methods: `isDownloaded`, `isDownloading`, `getProgress`, `getFileSize`, and `removeCache`.
*   **`DownloadManagerViewController`:**
    *   New view controller to list chapters and manage their download status.
    *   Displays download progress, file size, and status (Download, Downloading, Downloaded).
    *   Allows users to start downloads and delete cached files.
    *   Uses `withObservationTracking` for reactive UI updates.
*   **`ViewController`:**
    *   Added a navigation bar button to open the Download Manager.
    *   Wrapped the root view controller in a `UINavigationController` in `SceneDelegate`.
*   **Other:**
    *   Added `HConstants.appTitle`.
    *   Updated project documentation and agent prompts.

Closes #16