### PR TITLE
feat: Add remote toggle play/pause command support

### DIFF
--- a/.github/prompts/create_new_pr.prompt.md
+++ b/.github/prompts/create_new_pr.prompt.md
@@ -1,5 +1,5 @@
 ---
-agent: agent
+agent: github
 tools: ['execute/getTerminalOutput', 'execute/runInTerminal', 'github/create_pull_request']
 ---
 1. **Branch Management**:

--- a/Ye-Dufu/Packages/HMedia/Sources/HMedia/AudioPlayerModel.swift
+++ b/Ye-Dufu/Packages/HMedia/Sources/HMedia/AudioPlayerModel.swift
@@ -164,6 +164,15 @@ public class AudioPlayerModel {
     private func setupRemoteCommands() {
         let commandCenter = MPRemoteCommandCenter.shared()
 
+        commandCenter.togglePlayPauseCommand.isEnabled = true
+        commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
+            Task { @MainActor [weak self] in
+                HLog.info("Remote toggle play/pause command received", category: .media)
+                self?.togglePlayPause()
+            }
+            return .success
+        }
+
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { [weak self] _ in
             Task { @MainActor [weak self] in


### PR DESCRIPTION
This PR adds support for the `togglePlayPauseCommand` in `MPRemoteCommandCenter`. This allows users to play and pause media from the lock screen and control center using the toggle button.

Key changes:
- Enabled `togglePlayPauseCommand` in `AudioPlayerModel`.
- Added handler to call `togglePlayPause()` when the command is received.